### PR TITLE
feat!: Move to npm as the package ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+- package-ecosystem: "npm"
+  directory: "/"
+  schedule:
+    interval: "weekly"

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           echo "module.exports = { output: 'export', basePath: '/${{ github.event.repository.name }}' }" >  ./node_modules/${{ fromJson(steps.static.outputs.result)._static.generator.name }}/next.config.js
       - run: npx next build ./node_modules/${{ fromJson(steps.static.outputs.result)._static.generator.name }}
-      - run: cp ./node_modules/${{ fromJson(steps.static.outputs.result)._static.generator.name }}/out ./out
+      - run: cp -r ./node_modules/${{ fromJson(steps.static.outputs.result)._static.generator.name }}/out ./out
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,8 +30,7 @@ jobs:
         # changes to the next.config.js file to merge instead of overwrite.
         # with: 
         #   static_site_generator: next
-      # Parses the defined static.json file for use in steps; This will also ensure the user-provided static.json contents
-      # are persited after we clone the builder repository.
+      # Parses the defined static.json file for use in steps and injects "_static" internal configuration.
       - name: Parse static.json
         id: static
         uses: actions/github-script@v7
@@ -40,6 +39,7 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const staticConfig = JSON.parse(fs.readFileSync('./static.json', 'utf8'));
+            staticConfig._static = staticConfig._static || packageJson._static || {};
             staticConfig._static.host = {
               "base_url": "${{ steps.configure-pages.outputs.base_url }}",
               "origin": "${{ steps.configure-pages.outputs.origin }}",
@@ -47,11 +47,6 @@ jobs:
               "base_path": "${{ steps.configure-pages.outputs.base_path }}",
             };
             return staticConfig;
-      # Clone the builder repository referenced in the static.json file.
-      - name: Clone Builder
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ fromJson(steps.static.outputs.result)._static.generator }}
       # Build the Next.js application and create an artifact for deployment.
       - name: Build
         uses: actions/setup-node@v4
@@ -59,13 +54,14 @@ jobs:
           cache: npm
           node-version: lts/iron
       - run: npm ci
-      # Ensure the static.json file is the user-defined file and not the builder's file.
+      # Ensure the static.json file is the user-defined file and not the generator's file.
       - run: |
-          echo -e '${{steps.static.outputs.result}}' > static.json
+          echo -e '${{steps.static.outputs.result}}' > ./node_modules/${{ fromJson(steps.static.outputs.result)._static.generator.name }}/static.json
       - name: Update Next.js Configuration
         run: |
-          echo "module.exports = { output: 'export', basePath: '/${{ github.event.repository.name }}' }" > next.config.js
-      - run: npm run build
+          echo "module.exports = { output: 'export', basePath: '/${{ github.event.repository.name }}' }" >  ./node_modules/${{ fromJson(steps.static.outputs.result)._static.generator.name }}/next.config.js
+      - run: npx next build ./node_modules/${{ fromJson(steps.static.outputs.result)._static.generator.name }}
+      - run: cp ./node_modules/${{ fromJson(steps.static.outputs.result)._static.generator.name }}/out ./out
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -39,7 +39,7 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const staticConfig = JSON.parse(fs.readFileSync('./static.json', 'utf8'));
-            staticConfig._static = staticConfig._static || packageJson._static || {};
+            staticConfig._static = staticConfig._static || {};
             staticConfig._static.host = {
               "base_url": "${{ steps.configure-pages.outputs.base_url }}",
               "origin": "${{ steps.configure-pages.outputs.origin }}",

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -36,17 +36,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const fs = require('fs');
-            const path = require('path');
-            const staticConfig = JSON.parse(fs.readFileSync('./static.json', 'utf8'));
-            staticConfig._static = staticConfig._static || {};
-            staticConfig._static.host = {
-              "base_url": "${{ steps.configure-pages.outputs.base_url }}",
-              "origin": "${{ steps.configure-pages.outputs.origin }}",
-              "host": "${{ steps.configure-pages.outputs.host }}",
-              "base_path": "${{ steps.configure-pages.outputs.base_path }}",
-            };
-            return staticConfig;
+            const parseStatic = require('../../scripts/parse-static.js');
+            return parseStatic({
+              state: {
+                host: {
+                  "base_url": "${{ steps.configure-pages.outputs.base_url }}",
+                  "origin": "${{ steps.configure-pages.outputs.origin }}",
+                  "host": "${{ steps.configure-pages.outputs.host }}",
+                  "base_path": "${{ steps.configure-pages.outputs.base_path }}",
+                }
+              }
+            });
       # Build the Next.js application and create an artifact for deployment.
       - name: Build
         uses: actions/setup-node@v4

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Update Next.js Configuration
         run: |
           echo "module.exports = { output: 'export', basePath: '/${{ github.event.repository.name }}' }" >  ./node_modules/${{ fromJson(steps.static.outputs.result)._static.generator.name }}/next.config.js
-      - run: npx next build ./node_modules/${{ fromJson(steps.static.outputs.result)._static.generator.name }}
+      - run: cd ./node_modules/${{ fromJson(steps.static.outputs.result)._static.generator.name }} && npm run build
       - run: cp -r ./node_modules/${{ fromJson(steps.static.outputs.result)._static.generator.name }}/out ./out
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,37 +31,39 @@ jobs:
         # with: 
         #   static_site_generator: next
       # Parses the defined static.json file for use in steps and injects "_static" internal configuration.
-      - name: Parse static.json
+      - name: Parsing static.json
         id: static
         uses: actions/github-script@v7
         with:
           script: |
-            const parseStatic = require('../../scripts/parse-static.js');
-            return parseStatic({
-              state: {
-                host: {
-                  "base_url": "${{ steps.configure-pages.outputs.base_url }}",
-                  "origin": "${{ steps.configure-pages.outputs.origin }}",
-                  "host": "${{ steps.configure-pages.outputs.host }}",
-                  "base_path": "${{ steps.configure-pages.outputs.base_path }}",
-                }
+            const utils = require('../../scripts/static-utils.js');
+            return utils.parse({ core }, {
+              host: {
+                "base_url": "${{ steps.configure-pages.outputs.base_url }}",
+                "origin": "${{ steps.configure-pages.outputs.origin }}",
+                "host": "${{ steps.configure-pages.outputs.host }}",
+                "base_path": "${{ steps.configure-pages.outputs.base_path }}",
               }
             });
-      # Build the Next.js application and create an artifact for deployment.
-      - name: Build
+      # Build the application and create an artifact for deployment.
+      - name: Configure Node.js
         uses: actions/setup-node@v4
         with:
           cache: npm
           node-version: lts/iron
-      - run: npm ci
+      - name: Install Dependencies
+        run: npm ci
       # Ensure the static.json file is the user-defined file and not the generator's file.
-      - run: |
+      - name: Replacing static.json in Generator
+        run: |
           echo -e '${{steps.static.outputs.result}}' > ./node_modules/${{ fromJson(steps.static.outputs.result)._static.generator.name }}/static.json
       - name: Update Next.js Configuration
         run: |
           echo "module.exports = { output: 'export', basePath: '/${{ github.event.repository.name }}' }" >  ./node_modules/${{ fromJson(steps.static.outputs.result)._static.generator.name }}/next.config.js
-      - run: cd ./node_modules/${{ fromJson(steps.static.outputs.result)._static.generator.name }} && npm run build
-      - run: cp -r ./node_modules/${{ fromJson(steps.static.outputs.result)._static.generator.name }}/out ./out
+      - name: "Building from ${{ fromJson(steps.static.outputs.result)._static.generator.name }}"
+        run: cd ./node_modules/${{ fromJson(steps.static.outputs.result)._static.generator.name }} && npm run build
+      - name: Copying Output to Base Directory
+        run: cp -r ./node_modules/${{ fromJson(steps.static.outputs.result)._static.generator.name }}/out ./out
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -46,15 +46,15 @@ The `static` workflow injects the following properties into the provided `static
 
 
 - Sourced from [`actions/configure-pages@4`](https://github.com/actions/configure-pages/blob/1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d/action.yml#L22)
-  - `_static.base_url`
+  - `_static.host.base_url`
     - GitHub Pages site full base URL.
     - Exampls: `"https://from-static.github.io/static-resume"`, `"https://www.example.com"`
-  - `_static.origin`
+  - `_static.host.origin`
     - GitHub Pages site origin.
     - Example: `"https://from-static.github.io"`, `"https://www.example.com"`
-  - `_static.host`
+  - `_static.host.host`
     - GitHub Pages site host.
     - Example: `"from-static.github.io"`, `"www.example.com"`
-  - `_static.base_path`
+  - `_static.host.base_path`
     - GitHub Pages site full base path.
     - Example: `"/static-resume"`, `""`

--- a/scripts/parse-static.js
+++ b/scripts/parse-static.js
@@ -1,0 +1,9 @@
+module.exports = ({ state }) => {
+  const fs = require('fs');
+  const staticConfig = JSON.parse(fs.readFileSync('./static.json', 'utf8'));
+  staticConfig._static = staticConfig._static || {};
+  staticConfig._static.host = {
+    ...state.host || {}
+  };
+  return staticConfig;
+}

--- a/scripts/parse-static.js
+++ b/scripts/parse-static.js
@@ -1,9 +1,0 @@
-module.exports = ({ state }) => {
-  const fs = require('fs');
-  const staticConfig = JSON.parse(fs.readFileSync('./static.json', 'utf8'));
-  staticConfig._static = staticConfig._static || {};
-  staticConfig._static.host = {
-    ...state.host || {}
-  };
-  return staticConfig;
-}

--- a/scripts/static-utils.js
+++ b/scripts/static-utils.js
@@ -1,0 +1,56 @@
+// @ts-check
+
+/**
+* Parse a `static.json` file and return the JSON object.
+* @param {object} env - Environment packages from the Github Action (i.e. core, github, context)
+* @param {object} state - State from the Github Action (i.e. outputs)
+*/
+function parse({ core }, state = {}) {
+ const fs = require('fs');
+ let config = {};
+ try {
+   config = JSON.parse(fs.readFileSync('./static.json', 'utf8'));
+ } catch (e) {
+   core.setFailed(`Unable to parse static.json: ${e.message}`);
+ }
+ // Merge GitHub Action state with the parsed static.json
+ config = {
+   _static: {
+    host: {
+      ...state.host,
+    },
+    ...config._static,
+   }
+ }
+
+ try {
+   validate(config);
+ } catch (e) {
+   core.setFailed(`Invalid static.json: ${e.message}`);
+ }
+ return config;
+}
+
+/**
+ * A basic validation function for the `static.json` file.
+ */
+function validate(config) {
+  if (!config) {
+    throw new Error('No configuration provided.');
+  }
+  if (!('_static' in config) || !config._static) {
+    throw new Error('`_static` member not found in configuration.');
+  }
+  if (!config._static?.generator) {
+    throw new Error('A `generator` is required in a `_static` configuration.');
+  }
+  if (config._static?.ecosystem && config._static?.ecosystem !== 'npm') {
+    throw new Error('Unknown ecosystem provided. `npm` is currently the only official supported ecosystem.');
+  }
+  return true;
+}
+
+module.exports = {
+  parse,
+  validate,
+}


### PR DESCRIPTION
The shared static action will no longer build using `git clone`. Instead, generators are expected to be published `npm` packages. This change will allow cloned repositories to take advantage of dependabot functionality for keeping generators up-to-date and provide generator-authors with the ability to better reach downstream consumers (release notes).

- Adds a default `dependabot.yml` useful for this repository _and_ as a suggestion for downstream templates.
- Moves `static.json` processing to a JS file to allow test coverage (_soon_™).
