### PR TITLE
feat: allow overriding of any generator file via 'overrides' directory

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -131,6 +131,12 @@ jobs:
           STATIC_JSON: ${{ steps.static.outputs.result }}
         run: |
           jq -r '.' <<<"$STATIC_JSON" > ./.static--generator/static.json
+      # Sync the user-defined overrides directory to the generator's directory.
+      - name: Syncing Overrides
+        run: |
+          if [ -d "./overrides" ]; then
+            rsync -av ./overrides/ ./.static--generator/
+          fi
       # Call the ecosystem's default install and build command.
       - name: "Building from ${{ fromJson(steps.static.outputs.result)._static.generator.name }}"
         run: cd ./.static--generator && npm ci && npm run build


### PR DESCRIPTION
If the calling repository has a `overrides` directory, its contents will be merged (via `rsync`) with the cloned generator code.

This is useful for overriding specific behavior in generators that can't easily be expressed through the `static.json` file itself (i.e., provide a custom component for rendering some deep leaf UI element, providing a theme configuration for something like Chakra UI, etc.).

