### PR TITLE
feat: adds support for package.json merging

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -162,9 +162,9 @@ jobs:
       #
       - name: Merge the package.json, removing the targeted generator from the dependencies.
         run: |
-          jq -s '.[0] * .[1] | del(.dependencies["${{ fromJson(steps.static.outputs.result)._static.generator.name }}"])' ./.static--generator/package.json package.json > ./.static--generator/package.json
+          jq -s '.[0] * .[1] | del(.dependencies["${{ fromJson(steps.static.outputs.result)._static.generator.name }}"])' ./.static--generator/package.json package.json > ./merged--package.json && mv ./merged--package.json ./.static--generator/package.json
       - name: "Building from ${{ fromJson(steps.static.outputs.result)._static.generator.name }}"
-        run: cd ./.static--generator && npm ci && npm run build
+        run: cd ./.static--generator && npm install && npm run build
       - name: Copying Output to Base Directory
         run: cp -r ./.static--generator/out ./out
       - name: Upload artifact

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -155,7 +155,14 @@ jobs:
           if [ -d "./overrides" ]; then
             rsync -av ./overrides/ ./.static--generator/
           fi
-      # Call the ecosystem's default install and build command.
+      # [ECOSYSTEM SPECIFIC STEPS]
+      #
+      # At the moment, this action only supports `npm` as the ecosystem, but the steps below
+      # can be modified to support other ecosystems.
+      #
+      - name: Merge the package.json, removing the targeted generator from the dependencies.
+        run: |
+          jq -s '.[0] * .[1] | del(.dependencies["${{ fromJson(steps.static.outputs.result)._static.generator.name }}"])' ./.static--generator/package.json package.json > ./.static--generator/package.json
       - name: "Building from ${{ fromJson(steps.static.outputs.result)._static.generator.name }}"
         run: cd ./.static--generator && npm ci && npm run build
       - name: Copying Output to Base Directory


### PR DESCRIPTION
This will, in theory, will add support for downstream codebases to include arbitrary `dependencies` and `devDependencies` into a generator context. Using this functionality, in combination with `content` or `overrides` means you can easily include package-based code in custom content.

The below example shows how this would look to downstream codebases – the key thing to note is that this appears no different than installing and using a dependency as you would in any project using NPM.

```
content/
 index.mdx
static.json
package.json
```

```jsonc
// static.json
{
  "_static": {
    "generator": {
      "name": "@globus/static-search-portal"
    }
  },
  "data": {
    "version": "1.0.0",
    "attributes": { /* ... */ } 
   }
}
```

```jsonc
// package.json
{
    "dependencies": {
        "@globus/static-search-portal": "1.5.0",
        "d3": "^7.9.0"
    }
}
```

```jsx
// content/index.mdx
import * as d3 from 'd3';

# Welcome!

{{(function(){ console.log(d3);}()}}
```



